### PR TITLE
Fix ViewRowNoDoc emit for custom values

### DIFF
--- a/src/main/kotlin/org/taktik/couchdb/Client.kt
+++ b/src/main/kotlin/org/taktik/couchdb/Client.kt
@@ -956,9 +956,7 @@ class ClientImpl(
                                             ViewRowNoDoc(it, key, value)
                                         }
                                         emit(row)
-                                    } ?: if (value is Int || value is Long) {
-                                        emit(ViewRowNoDoc("", key, value))
-                                    }
+                                    } ?: emit(ViewRowNoDoc("", key, value))
 
                                 }
                             }


### PR DESCRIPTION
This pull request fixes an issue that prevented the emission of ViewRowNoDoc when they don't have an `id` and `value` are not a Number.

This behavior is problematic for views that can be reduced (and don't emit an `id`) and where we therefore need to create a custom value to handle the `id`.