### PR TITLE
Proper attachment stubbing

### DIFF
--- a/src/main/kotlin/org/taktik/couchdb/entity/Attachment.kt
+++ b/src/main/kotlin/org/taktik/couchdb/entity/Attachment.kt
@@ -31,11 +31,15 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class Attachment(
         @JsonIgnore val id: String? = null,
         @field:JsonProperty("content_type") val contentType: String? = null,
-        @JsonIgnore val contentLength: Long = 0,
+        @JsonIgnore val contentLength: Long? = null,
         @field:JsonProperty("data") val dataBase64: String? = null,
         @field:JsonProperty("stub")
         val isStub: Boolean = false,
-        val revpos: Int = 0,
+        val revpos: Int? = null,
         val digest: String? = null,
         val length: Long? = null
-)
+) {
+    companion object {
+        val EmptyStub = Attachment(isStub = true)
+    }
+}


### PR DESCRIPTION
Allows to update entities without specifying the full attachment info